### PR TITLE
AJ-1194 - Use updated version of bumper GHA

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,7 +11,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version
         # https://github.com/DataBiosphere/github-actions/tree/master/actions/bumper
-        uses: databiosphere/github-actions/actions/bumper@bumper-0.0.6
+        uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
         id: tag
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_TOKEN }}


### PR DESCRIPTION
We're getting warning errors for the outdated set-output GHA functionality. 

Warning messages:
![image](https://github.com/DataBiosphere/java-pfb/assets/13254229/3e6a1ac0-d904-453e-aa87-160619305ab2)


Example successful run: https://github.com/DataBiosphere/java-pfb/actions/runs/5615070466/job/15214546369