### PR TITLE
AJ-1202: Fix sourceclear scan 

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,5 +13,5 @@ repositories {
 apply from: 'generators.gradle'
 
 srcclr {
-    scope = "runtime"
+    scope = "runtimeClasspath"
 }


### PR DESCRIPTION
### Background
Before this change, no modules were getting scanned by sourceclear.  Switching the srcclr's source from "runtime" to "runtimeClasspath" has allowed for one module to be scanned. The "runtime" gradle scope is no longer used for java compilation with recent versions of gradle.

<img width="570" alt="image" src="https://github.com/DataBiosphere/java-pfb/assets/13254229/2ab553e2-de03-480d-9900-2c29d028a2c5">

### Testing the Change
Since we're still not seeing any vulnerabilities in this repo, I added another dependency to test the functionality. This added library was not picked up by sourceclear when the source was set to "runtime", but it was successful when it was set to "runtimeClasspath". 

**Thank you, @pshapiro4broad, for figuring this out.** 
