### PR TITLE
AJ-1095: Publish Fix

### DIFF
--- a/.github/workflows/build-test-and-publish.yml
+++ b/.github/workflows/build-test-and-publish.yml
@@ -71,43 +71,43 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  tag:
-    needs: [ build, unit-tests-and-sonarqube, source-clear ]
-    uses: ./.github/workflows/tag.yml
-    if: success() && github.ref == 'refs/heads/main'
-    secrets: inherit
+#  tag:
+#    needs: [ build, unit-tests-and-sonarqube, source-clear ]
+#    uses: ./.github/workflows/tag.yml
+#    if: success() && github.ref == 'refs/heads/main'
+#    secrets: inherit
 
   publish-library:
-    needs: [ tag ]
+    needs: [ build, unit-tests-and-sonarqube, source-clear ]
     uses: ./.github/workflows/publish.yml
-    if: success() && github.ref == 'refs/heads/main'
+    if: success()
     secrets: inherit
     with:
-      tag: ${{ needs.tag.outputs.tag }}
+      tag: '0.2.0'
 
-  release-cli:
-    needs: [ tag ]
-    uses: ./.github/workflows/release-cli.yml
-    secrets: inherit
-    if: success() && github.ref == 'refs/heads/main'
-    with:
-      tag: ${{ needs.tag.outputs.tag }}
+#  release-cli:
+#    needs: [ tag ]
+#    uses: ./.github/workflows/release-cli.yml
+#    secrets: inherit
+#    if: success() && github.ref == 'refs/heads/main'
+#    with:
+#      tag: ${{ needs.tag.outputs.tag }}
 
-  notify-slack-on-failure:
-    needs: [ build, unit-tests-and-sonarqube, source-clear, tag, publish-library, release-cli ]
-    runs-on: ubuntu-latest
-
-    if: failure() && github.ref == 'refs/heads/main'
-
-    steps:
-      - name: Notify slack on failure
-        uses: broadinstitute/action-slack@v3.8.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          channel: '#dsp-analysis-journeys-alerts'
-          status: failure
-          author_name: Build on dev
-          fields: job,message
-          text: 'Build failed :sadpanda:'
-          username: 'Java-PFB GitHub Action'
+#  notify-slack-on-failure:
+#    needs: [ build, unit-tests-and-sonarqube, source-clear, tag, publish-library, release-cli ]
+#    runs-on: ubuntu-latest
+#
+#    if: failure() && github.ref == 'refs/heads/main'
+#
+#    steps:
+#      - name: Notify slack on failure
+#        uses: broadinstitute/action-slack@v3.8.0
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#        with:
+#          channel: '#dsp-analysis-journeys-alerts'
+#          status: failure
+#          author_name: Build on dev
+#          fields: job,message
+#          text: 'Build failed :sadpanda:'
+#          username: 'Java-PFB GitHub Action'

--- a/.github/workflows/build-test-and-publish.yml
+++ b/.github/workflows/build-test-and-publish.yml
@@ -71,43 +71,43 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-#  tag:
-#    needs: [ build, unit-tests-and-sonarqube, source-clear ]
-#    uses: ./.github/workflows/tag.yml
-#    if: success() && github.ref == 'refs/heads/main'
-#    secrets: inherit
+  tag:
+    needs: [ build, unit-tests-and-sonarqube, source-clear ]
+    uses: ./.github/workflows/tag.yml
+    if: success() && github.ref == 'refs/heads/main'
+    secrets: inherit
 
   publish-library:
-    needs: [ build, unit-tests-and-sonarqube, source-clear ]
+    needs: [ tag ]
     uses: ./.github/workflows/publish.yml
-    if: success()
+    if: success() && github.ref == 'refs/heads/main'
     secrets: inherit
     with:
-      tag: '0.2.0'
+      tag: ${{ needs.tag.outputs.tag }}
 
-#  release-cli:
-#    needs: [ tag ]
-#    uses: ./.github/workflows/release-cli.yml
-#    secrets: inherit
-#    if: success() && github.ref == 'refs/heads/main'
-#    with:
-#      tag: ${{ needs.tag.outputs.tag }}
+  release-cli:
+    needs: [ tag ]
+    uses: ./.github/workflows/release-cli.yml
+    secrets: inherit
+    if: success() && github.ref == 'refs/heads/main'
+    with:
+      tag: ${{ needs.tag.outputs.tag }}
 
-#  notify-slack-on-failure:
-#    needs: [ build, unit-tests-and-sonarqube, source-clear, tag, publish-library, release-cli ]
-#    runs-on: ubuntu-latest
-#
-#    if: failure() && github.ref == 'refs/heads/main'
-#
-#    steps:
-#      - name: Notify slack on failure
-#        uses: broadinstitute/action-slack@v3.8.0
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#        with:
-#          channel: '#dsp-analysis-journeys-alerts'
-#          status: failure
-#          author_name: Build on dev
-#          fields: job,message
-#          text: 'Build failed :sadpanda:'
-#          username: 'Java-PFB GitHub Action'
+  notify-slack-on-failure:
+    needs: [ build, unit-tests-and-sonarqube, source-clear, tag, publish-library, release-cli ]
+    runs-on: ubuntu-latest
+
+    if: failure() && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Notify slack on failure
+        uses: broadinstitute/action-slack@v3.8.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          channel: '#dsp-analysis-journeys-alerts'
+          status: failure
+          author_name: Build on dev
+          fields: job,message
+          text: 'Build failed :sadpanda:'
+          username: 'Java-PFB GitHub Action'

--- a/.github/workflows/build-test-and-publish.yml
+++ b/.github/workflows/build-test-and-publish.yml
@@ -1,7 +1,13 @@
 name: Build, Test and Publish
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'If true, run the tag and publish jobs'
+        required: true
+        type: boolean
+        default: false
   push:
     branches: [ main ]
     paths-ignore:
@@ -74,13 +80,13 @@ jobs:
   tag:
     needs: [ build, unit-tests-and-sonarqube, source-clear ]
     uses: ./.github/workflows/tag.yml
-    if: success() && github.ref == 'refs/heads/main'
+    if: success() && (github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && inputs.publish))
     secrets: inherit
 
   publish-library:
     needs: [ tag ]
     uses: ./.github/workflows/publish.yml
-    if: success() && github.ref == 'refs/heads/main'
+    if: success() && (github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && inputs.publish))
     secrets: inherit
     with:
       tag: ${{ needs.tag.outputs.tag }}
@@ -89,7 +95,7 @@ jobs:
     needs: [ tag ]
     uses: ./.github/workflows/release-cli.yml
     secrets: inherit
-    if: success() && github.ref == 'refs/heads/main'
+    if: success() && (github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && inputs.publish))
     with:
       tag: ${{ needs.tag.outputs.tag }}
 

--- a/.github/workflows/build-test-and-publish.yml
+++ b/.github/workflows/build-test-and-publish.yml
@@ -1,6 +1,7 @@
 name: Build, Test and Publish
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [ main ]
     paths-ignore:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
       - name: Publish Library Artifactory
-        run: ./gradlew --build-cache :library:artifactoryPublish
+        run: ./gradlew --build-cache artifactoryPublish
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 name: Publish Library to Artifactory
 on:
+  workflow_dispatch: {}
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,6 @@ env:
 
 jobs:
   publish-job:
-    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
       tag:
         description: 'Enter a valid tag for the release'
         required: true
+        type: string
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,10 @@
 name: Publish Library to Artifactory
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Enter a valid tag for the release'
+        required: true
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,6 +1,10 @@
 name: Create Github Release with CLI Jar and Distribution
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Enter a valid tag for the release'
+        required: true
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -5,6 +5,7 @@ on:
       tag:
         description: 'Enter a valid tag for the release'
         required: true
+        type: string
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,5 +1,6 @@
 name: Create Github Release with CLI Jar and Distribution
 on:
+  workflow_dispatch: {}
   workflow_call:
     inputs:
       tag:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,5 +1,6 @@
 name: Tag
 on:
+  workflow_dispatch: {}
   workflow_call:
     outputs:
       tag:


### PR DESCRIPTION
- Publish action wasn't triggered with the last merge - There were two issues: (1) We had a lingering "if" condition on the publish job that is no longer relevant and (2) The publish command is now run directly instead of needing to specify the library subproject. (We originally had an aritfactoryPublish job for both the CLI and the library. But, we are no longer publishing the CLI to artifactory, so we can run "./gradlew artifactoryPublish" and it will only publish the library. )
- While working on this fix, I found that it would have been easier to debug if we had enabled "workflow_dispatch" on all of the actions so that I could have kicked them off from the UI and specified a branch to run them on. While enabling this, I also added "inputs" so we could easily specify the tag for the publish actions and whether or not to run publish on the main action. 