### PR TITLE
AJ-1095 - Fix Publish logic - Enable skipping publish on main branch

### DIFF
--- a/.github/workflows/build-test-and-publish.yml
+++ b/.github/workflows/build-test-and-publish.yml
@@ -80,13 +80,13 @@ jobs:
   tag:
     needs: [ build, unit-tests-and-sonarqube, source-clear ]
     uses: ./.github/workflows/tag.yml
-    if: success() && (github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && inputs.publish))
+    if: success() && ((github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && inputs.publish))
     secrets: inherit
 
   publish-library:
     needs: [ tag ]
     uses: ./.github/workflows/publish.yml
-    if: success() && (github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && inputs.publish))
+    if: success() && ((github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && inputs.publish))
     secrets: inherit
     with:
       tag: ${{ needs.tag.outputs.tag }}
@@ -95,7 +95,7 @@ jobs:
     needs: [ tag ]
     uses: ./.github/workflows/release-cli.yml
     secrets: inherit
-    if: success() && (github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && inputs.publish))
+    if: success() && ((github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && inputs.publish))
     with:
       tag: ${{ needs.tag.outputs.tag }}
 


### PR DESCRIPTION
Once merging the last change, I tested running test action without publishing, but it still ran the publish action. So, I needed to re-work the logic a bit. 

Now:
- Does NOT run publish on PR run OR on one-off dispatch when "publish" is set to false
- Runs publish when referencing main OR when one-off dispatch has "publish" set to true

![image](https://github.com/DataBiosphere/java-pfb/assets/13254229/13dbe066-c686-4133-9a93-2ebd5a264341)
