### PR TITLE
AJ-1370: avro library is an api dependency

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,8 +22,8 @@ repositories {
 }
 
 dependencies {
+    api "org.apache.avro:avro:1.11.3"
     implementation 'ch.qos.logback:logback-classic:1.2.9'
-    implementation "org.apache.avro:avro:1.11.2"
     implementation 'org.xerial.snappy:snappy-java:1.1.10.3'
     testImplementation 'org.json:json:20230618'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'


### PR DESCRIPTION
* update `org.apache.avro:avro` from `1.11.2` to `1.11.3`
* change `org.apache.avro:avro` from an `implementation` dependency to an `api` dependency. Hopefully this avoids java-pfb consumers from having to manually specify avro as a dependency; see [this PR comment](https://github.com/DataBiosphere/terra-workspace-data-service/pull/382#discussion_r1370345257).
* reorganize dependencies slightly so `api` and `implementation` deps are grouped together