### PR TITLE
AJ-1396 remove snappy to fix security vulnerability

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -24,7 +24,7 @@ repositories {
 dependencies {
     api "org.apache.avro:avro:1.11.3"
     implementation 'ch.qos.logback:logback-classic:1.2.9'
-    implementation 'org.xerial.snappy:snappy-java:1.1.10.3'
+    implementation 'org.xerial.snappy:snappy-java:1.1.10.4'
     testImplementation 'org.json:json:20230618'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     testImplementation 'org.skyscreamer:jsonassert:1.2.3'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -24,7 +24,6 @@ repositories {
 dependencies {
     api "org.apache.avro:avro:1.11.3"
     implementation 'ch.qos.logback:logback-classic:1.2.9'
-    implementation 'org.xerial.snappy:snappy-java:1.1.10.4'
     testImplementation 'org.json:json:20230618'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
     testImplementation 'org.skyscreamer:jsonassert:1.2.3'


### PR DESCRIPTION
The snappy-java library caused a [security alert in wds](https://github.com/DataBiosphere/terra-workspace-data-service/security/dependabot/38), which uses this library.  Snappy-java is no longer needed by this project, so this PR removes it from the dependencies.