### PR TITLE
AJ-1288: enum decoding

### DIFF
--- a/library/src/main/java/bio/terra/pfb/PfbReader.java
+++ b/library/src/main/java/bio/terra/pfb/PfbReader.java
@@ -154,7 +154,7 @@ public class PfbReader {
 
     return matcher.replaceAll(
         capture -> {
-          int codepoint = Integer.parseInt(capture.group(1));
+          int codepoint = Integer.parseInt(capture.group(1), 16);
           // don't decode control characters
           if (codepoint > 31) {
             return new String(Character.toChars(codepoint));

--- a/library/src/main/java/bio/terra/pfb/PfbReader.java
+++ b/library/src/main/java/bio/terra/pfb/PfbReader.java
@@ -24,9 +24,9 @@ public class PfbReader {
   private static final Pattern ENUM_PATTERN = Pattern.compile("_([A-Fa-f0-9]{2,3})_");
 
   public static String showSchema(String fileLocation) throws IOException {
-    // TODO AJ-1288: the use of convertEnum here is incorrect. It performs decoding on the entire string output of
-    //    the schema. Instead, it should only perform decoding on the individual values of ENUM fields within
-    //    schemas.
+    // TODO AJ-1288: the use of convertEnum here is incorrect. It performs decoding on the entire
+    //     string output of the schema. Instead, it should only perform decoding on the individual
+    //     values of ENUM fields within schemas.
     return convertEnum(
         getPfbSchema(fileLocation).stream().map(Schema::toString).toList().toString());
   }
@@ -48,9 +48,9 @@ public class PfbReader {
 
     try (DataFileStream<GenericRecord> records = PfbReader.getGenericRecordsStream(fileLocation)) {
       while (records.hasNext()) {
-        // TODO AJ-1288: the use of convertEnum here is incorrect. It performs decoding on the entire string output of
-        //    a record. Instead, it should only perform decoding on the individual values of ENUM fields within
-        //    that record.
+        // TODO AJ-1288: the use of convertEnum here is incorrect. It performs decoding on the
+        //     entire string output of a record. Instead, it should only perform decoding on the
+        //     individual values of ENUM fields within that record.
         data.add(convertEnum(records.next().toString()));
       }
       return data;
@@ -147,6 +147,9 @@ public class PfbReader {
    * _32_ and greater sign > into _62_. Same for Unicode characters: ä - _228_, ü - _252_. The Avro
    * schema also doesn't allow for the first character to be a number. So we encode the first
    * character in the way if the character happens to be a number."
+   *
+   * <p>IMPORTANT: the above quote from the pypfb repo is incorrect - "bpm > 60" will actually be
+   * encoded as "bpm_20__3e__20_60", because encoding uses hex instead of decimal codepoints.
    *
    * <p>This method has slightly different behavior than pypfb: this method does not decode any
    * characters below codepoint 32, as those are control characters and deemed unsafe.

--- a/library/src/main/java/bio/terra/pfb/PfbReader.java
+++ b/library/src/main/java/bio/terra/pfb/PfbReader.java
@@ -21,9 +21,12 @@ import org.apache.avro.specific.SpecificDatumReader;
 public class PfbReader {
 
   // regex for decoding enums. See convertEnum().
-  private static final Pattern ENUM_PATTERN = Pattern.compile("_([A-Fa-f0-9]{2,})_");
+  private static final Pattern ENUM_PATTERN = Pattern.compile("_([A-Fa-f0-9]{2,3})_");
 
   public static String showSchema(String fileLocation) throws IOException {
+    // TODO AJ-1288: the use of convertEnum here is incorrect. It performs decoding on the entire string output of
+    //    the schema. Instead, it should only perform decoding on the individual values of ENUM fields within
+    //    schemas.
     return convertEnum(
         getPfbSchema(fileLocation).stream().map(Schema::toString).toList().toString());
   }
@@ -45,6 +48,9 @@ public class PfbReader {
 
     try (DataFileStream<GenericRecord> records = PfbReader.getGenericRecordsStream(fileLocation)) {
       while (records.hasNext()) {
+        // TODO AJ-1288: the use of convertEnum here is incorrect. It performs decoding on the entire string output of
+        //    a record. Instead, it should only perform decoding on the individual values of ENUM fields within
+        //    that record.
         data.add(convertEnum(records.next().toString()));
       }
       return data;

--- a/library/src/test/java/bio/terra/pfb/PfbReaderTest.java
+++ b/library/src/test/java/bio/terra/pfb/PfbReaderTest.java
@@ -158,13 +158,19 @@ class PfbReaderTest {
   // arguments for the convertEnum test: pairs of input, expected.
   static Stream<Arguments> provideConvertEnumArguments() {
     return Stream.of(
-        Arguments.of("bpm_32__62__32_60", "bpm > 60"),
-        Arguments.of("_48_1234", "01234"), // leading numbers are encoded
-        Arguments.of("_00__07__27_", "_00__07__27_"), // don't decode control characters
-        Arguments.of("email_64_domain_46_tld", "email@domain.tld"),
-        Arguments.of("a_47_path_47_", "a/path/"),
-        Arguments.of("open_123_brace_125_close", "open{brace}close") // 3-digit controls
-        );
+        // "bpm > 60" is the example from
+        // https://github.com/uc-cdis/pypfb/blob/master/docs/detailed_pfb_doc.md#enum,
+        // but I am convinced that example is incorrect
+        Arguments.of("bpm_20__3E__20_60", "bpm > 60"),
+        // leading numbers are encoded
+        Arguments.of("_30_1234", "01234"),
+        // don't decode control characters
+        Arguments.of("_00__07__1B__1F_", "_00__07__1B__1F_"),
+        Arguments.of("email_40_domain_2E_tld", "email@domain.tld"),
+        Arguments.of("a_2F_path_2F_", "a/path/"),
+        Arguments.of("open_7B_brace_7D_close", "open{brace}close"),
+        // 3-digit chars
+        Arguments.of("zz_1B5_ligature_152_", "zzƵligatureŒ"));
   }
 
   @ParameterizedTest(name = "for input [{0}], should decode to [{1}]")

--- a/library/src/test/java/bio/terra/pfb/PfbReaderTest.java
+++ b/library/src/test/java/bio/terra/pfb/PfbReaderTest.java
@@ -154,4 +154,23 @@ class PfbReaderTest {
     CompareOutputUtils.compareJSONLineByLine(testFileName, SHOW, signedUrl);
     CompareOutputUtils.assertJavaPfbIsPyPFB(testFileName, SHOW_METADATA, signedUrl, JSON);
   }
+
+  // arguments for the convertEnum test: pairs of input, expected.
+  static Stream<Arguments> provideConvertEnumArguments() {
+    return Stream.of(
+        Arguments.of("bpm_32__62__32_60", "bpm > 60"),
+        Arguments.of("_48_1234", "01234"), // leading numbers are encoded
+        Arguments.of("_00__07__27_", "_00__07__27_"), // don't decode control characters
+        Arguments.of("email_64_domain_46_tld", "email@domain.tld"),
+        Arguments.of("a_47_path_47_", "a/path/"),
+        Arguments.of("open_123_brace_125_close", "open{brace}close") // 3-digit controls
+        );
+  }
+
+  @ParameterizedTest(name = "for input [{0}], should decode to [{1}]")
+  @MethodSource("provideConvertEnumArguments")
+  void convertEnum(String input, String expected) {
+    String actual = PfbReader.convertEnum(input);
+    assertEquals(expected, actual);
+  }
 }


### PR DESCRIPTION
This PR makes progress on AJ-1288 but does not completely satisfy that ticket, nor does it address all the problems.

PFBs encode special characters inside Avro enums; see https://github.com/uc-cdis/pypfb/blob/master/docs/detailed_pfb_doc.md#enum.

Before this PR, the java-pfb library looked for a hardcoded set of symbols and decoded only those symbols.

After this PR, it uses a regex to find any/all encoded characters and decodes those.

Still outstanding: see the TODO comments on `PfbReader.showSchema()` and `PfbReader.show()` - we should be decoding in a very targeted fashion, but the code currently decodes things that shouldn't be decoded. For instance, a field named "unit_cac_volume" triggers decoding to "unitಬvolume", though we should not attempt to decode it.