### PR TITLE
[AJ-1415] Add submit dependencies workflow

### DIFF
--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -1,7 +1,7 @@
 name: Gradle Dependency Submission
 on:
   workflow_dispatch:
-  push:
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -1,7 +1,7 @@
 name: Gradle Dependency Submission
 on:
   workflow_dispatch:
-  pull_request:
+  push:
     branches:
       - main
 

--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -1,0 +1,29 @@
+name: Gradle Dependency Submission
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Dependency Submission
+    runs-on: ubuntu-latest
+    permissions: # The Dependency Submission API requires write permission
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Submit Dependencies
+        uses: mikepenz/gradle-dependency-submission@v0.9.0
+        with:
+          gradle-build-module: |-
+            :library
+            :cli


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1415

It sounds like Dependabot support for Gradle is limited and requires the dependency graph to be manually uploaded.
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#gradle
- https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api

This copies the submit-dependencies.yml workflow from WDS and updates the `gradle-build-module` configuration.