### PR TITLE
[AJ-1415] Configure Dependabot to update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "gradle"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "@DataBiosphere/analysisjourneys"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/New_York"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1415

Attempting to configure Dependabot to automatically open PRs to update dependencies. Based on [GitHub documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) and [DataBiosphere/terra-landing-zone-service](https://github.com/DataBiosphere/terra-landing-zone-service)'s [Dependabot configuration](https://github.com/DataBiosphere/terra-landing-zone-service/blob/main/.github/dependabot.yml).

