### PR TITLE
[AJ-1415] Comment on PRs only when workflow has permission

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,9 +43,9 @@ jobs:
           # PR job summary, always off
           summary-always: false # see https://github.com/benchmark-action/github-action-benchmark/issues/158
           # Commit comment, always on
-          comment-always: true
+          comment-always: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
           # Commit comment when benchmarks are above threshold
-          comment-on-alert: true
+          comment-on-alert: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
           # Set a fairly high alert threshold, since GHA runners are variable
           alert-threshold: "150%"
           # Workflow will not fail when an alert happens


### PR DESCRIPTION
When triggered by a Dependabot PR, the benchmark action cannot comment on the PR because the workflow is run with a read-only token.

https://github.com/DataBiosphere/java-pfb/actions/runs/7145641685/job/19461744870?pr=28


This modifies the benchmark action to comment only when the workflow has write permission. That is, on pushes or on PRs that are within the repository (not from forks) and initiated by a user (not Dependabot).