### PR TITLE
[AJ-1556] Update action used to submit dependency graph

### DIFF
--- a/.github/workflows/submit-dependencies.yml
+++ b/.github/workflows/submit-dependencies.yml
@@ -12,18 +12,15 @@ jobs:
     permissions: # The Dependency Submission API requires write permission
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
 
-      - name: Submit Dependencies
-        uses: mikepenz/gradle-dependency-submission@v0.9.0
-        with:
-          gradle-build-module: |-
-            :library
-            :cli
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3


### PR DESCRIPTION
What https://github.com/DataBiosphere/terra-workspace-data-service/pull/512 did for WDS, this does for java-pfb.

From https://github.com/DataBiosphere/terra-workspace-data-service/pull/512:
> The action we were using for dependency submission - https://github.com/marketplace/actions/gradle-dependency-submission - is deprecated. This switches us to use the recommended solution which is provided directly by gradle.