### PR TITLE
[AJ-1415] Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,9 @@ updates:
       day: "monday"
       time: "08:00"
       timezone: "America/New_York"
+    groups:
+      minor-and-patch-updates:
+        applies-to: "version-updates"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
As in https://github.com/DataBiosphere/terra-workspace-data-service/pull/645, this configures Dependabot to group multiple updates into a single PR.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups