### PR TITLE
[AJ-1783] Configure Dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "@DataBiosphere/analysisjourneys"
+    commit-message:
+      prefix: "[AJ-1783]"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "America/New_York"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,8 @@ updates:
       day: "monday"
       time: "08:00"
       timezone: "America/New_York"
+    groups:
+      artifact-actions:
+        patterns:
+          - "actions/upload-artifact"
+          - "actions/download-artifact"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1783

This configures Dependabot to automatically update third party GitHub Actions used in workflows.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#github-actions