### PR TITLE
[CORE-69] Move dependabot updates from AJ to CORE

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,9 @@ updates:
       - "gradle"
     open-pull-requests-limit: 10
     reviewers:
-      - "@DataBiosphere/analysisjourneys"
+      - "@DataBiosphere/broad-core-services"
     commit-message:
-      prefix: "[AJ-1783]"
+      prefix: "[CORE-71]"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -28,9 +28,9 @@ updates:
       - "github-actions"
     open-pull-requests-limit: 10
     reviewers:
-      - "@DataBiosphere/analysisjourneys"
+      - "@DataBiosphere/broad-core-services"
     commit-message:
-      prefix: "[AJ-1783]"
+      prefix: "[CORE-71]"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     reviewers:
       - "@DataBiosphere/broad-core-services"
     commit-message:
-      prefix: "[CORE-71]"
+      prefix: "[CORE-69]"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -30,7 +30,7 @@ updates:
     reviewers:
       - "@DataBiosphere/broad-core-services"
     commit-message:
-      prefix: "[CORE-71]"
+      prefix: "[CORE-69]"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Dependabot automatically tags an associated ticket and the AJ team. The ticket was moved from AJ to CORE; this PR updates the ticket and which team is tagged on dependabot updates.