### PR TITLE
CORE-208: include stack traces in InvalidPfbExceptions

### DIFF
--- a/library/src/main/java/bio/terra/pfb/PfbReader.java
+++ b/library/src/main/java/bio/terra/pfb/PfbReader.java
@@ -55,7 +55,7 @@ public class PfbReader {
       }
       return data;
     } catch (IOException e) {
-      throw new InvalidPfbException("Error reading PFB Value object");
+      throw new InvalidPfbException("Error reading PFB Value object", e);
     }
   }
 
@@ -72,7 +72,7 @@ public class PfbReader {
       reader.next();
       return reader;
     } catch (Exception e) {
-      throw new InvalidPfbException("Error reading PFB Value object");
+      throw new InvalidPfbException("Error reading PFB Value object", e);
     }
   }
 

--- a/library/src/main/java/bio/terra/pfb/exceptions/InvalidPfbException.java
+++ b/library/src/main/java/bio/terra/pfb/exceptions/InvalidPfbException.java
@@ -4,4 +4,8 @@ public class InvalidPfbException extends RuntimeException {
   public InvalidPfbException(String message) {
     super(message);
   }
+
+  public InvalidPfbException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }


### PR DESCRIPTION
When reading the nodes of a PFB, we may throw `InvalidPfbException`. When we threw that, we omitted the stack trace. This makes debugging inside cWDS pretty hard; we can't see the underlying error that caused the problem.

This is a small PR to include the underlying cause in those exceptions.