### PR TITLE
[CORE-593] update jfrog to gar

### DIFF
--- a/.github/workflows/build-test-and-publish.yml
+++ b/.github/workflows/build-test-and-publish.yml
@@ -80,7 +80,8 @@ jobs:
   tag:
     needs: [ build, unit-tests-and-sonarqube, source-clear ]
     uses: ./.github/workflows/tag.yml
-    if: success() && ((github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && inputs.publish))
+    # if: success() && ((github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && inputs.publish))
+    if: success()
     secrets: inherit
 
   publish-library:

--- a/.github/workflows/build-test-and-publish.yml
+++ b/.github/workflows/build-test-and-publish.yml
@@ -80,15 +80,13 @@ jobs:
   tag:
     needs: [ build, unit-tests-and-sonarqube, source-clear ]
     uses: ./.github/workflows/tag.yml
-    # if: success() && ((github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && inputs.publish))
-    if: success()
+    if: success() && ((github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && inputs.publish))
     secrets: inherit
 
   publish-library:
     needs: [ tag ]
     uses: ./.github/workflows/publish.yml
-    # if: success() && ((github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && inputs.publish))
-    if: success()
+    if: success() && ((github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && inputs.publish))
     secrets: inherit
     with:
       tag: ${{ needs.tag.outputs.tag }}

--- a/.github/workflows/build-test-and-publish.yml
+++ b/.github/workflows/build-test-and-publish.yml
@@ -86,7 +86,8 @@ jobs:
   publish-library:
     needs: [ tag ]
     uses: ./.github/workflows/publish.yml
-    if: success() && ((github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && inputs.publish))
+    # if: success() && ((github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch') || (github.event_name == 'workflow_dispatch' && inputs.publish))
+    if: success()
     secrets: inherit
     with:
       tag: ${{ needs.tag.outputs.tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,9 +41,22 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
-      - name: Publish Library Artifactory
-        run: ./gradlew --build-cache artifactoryPublish
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+          service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
+      - name: Publish client to GAR
+        run: ./gradlew publish
         env:
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ARTIFACTORY_REPO_KEY: "libs-release-local"
+          GOOGLE_CLOUD_PROJECT: dsp-artifact-registry
+          GAR_LOCATION: us-central1
+          GAR_REPOSITORY_ID: libs-release-standard
+
+      # - name: Publish Library Artifactory
+      #   run: ./gradlew --build-cache artifactoryPublish
+      #   env:
+      #     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+      #     ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+      #     ARTIFACTORY_REPO_KEY: "libs-release-local"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish Library to Artifactory
+name: Publish Library to GAR
 on:
   workflow_dispatch:
     inputs:
@@ -33,8 +33,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          # ref: ${{ inputs.tag }}
-          ref: core-593-jfrog-to-gar
+          ref: ${{ inputs.tag }}
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -54,10 +53,3 @@ jobs:
           GOOGLE_CLOUD_PROJECT: dsp-artifact-registry
           GAR_LOCATION: us-central1
           GAR_REPOSITORY_ID: libs-release-standard
-
-      # - name: Publish Library Artifactory
-      #   run: ./gradlew --build-cache artifactoryPublish
-      #   env:
-      #     ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-      #     ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-      #     ARTIFACTORY_REPO_KEY: "libs-release-local"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag }}
+          # ref: ${{ inputs.tag }}
+          ref: core-593-jfrog-to-gar
           token: ${{ secrets.BROADBOT_TOKEN }}
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/library/README.md
+++ b/library/README.md
@@ -8,18 +8,21 @@ implementation "bio.terra:java-pfb-library:<Tagged Version>"
 You can find the latest tagged version on [Github](https://github.com/DataBiosphere/java-pfb/tags). 
 
 ## Publishing the Library
-JFrog Artifactory is used to publish libraries to a central Maven repository. The library version number is the version in settings.gradle. We use github actions to bump the version and publish to Artifactory.
+Google Artifact Registry (GAR) is used to publish libraries to a central Maven repository. The library version number is the version in settings.gradle. We use github actions to bump the version and publish to GAR.
 
 **The Publishing Procedure**
 
 1) After PR is merged to main branch:
    1) A Github Action bumps the minor version in settings.gradle and tags the release in github 
-   2) Github Action publishes to libs-release-local in Artifactory
+   2) Github Action publishes to libs-release-standard in GAR
 2) To bump major version, we need manually update version in settings.gradle value first then create the release.
 
 **Running Publish Locally**
+You'll need to have permission under your @broadinstitute account to publish to the registry.  If you don't, contact DevOps.
 ```shell
-export ARTIFACTORY_USERNAME=$(vault read -field=username secret/dsp/accts/artifactory/dsdejenkins)
-export ARTIFACTORY_PASSWORD=$(vault read -field=password secret/dsp/accts/artifactory/dsdejenkins)
-./gradlew artifactoryPublish
+export GOOGLE_CLOUD_PROJECT=dsp-artifact-registry
+export GAR_LOCATION=us-central1
+export GAR_REPOSITORY_ID=libs-release-standard
+gcloud auth login <you>@broadinstitute.org
+./gradlew publish
 ```

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'bio.terra.pfb.java-library-conventions'
     id 'com.github.davidmc24.gradle.plugin.avro' version '1.9.1'
     id 'me.champeau.jmh' version '0.7.3'
+    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.5'
 }
 
 repositories {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.srcclr.gradle'
     id 'maven-publish'
-    id 'com.jfrog.artifactory'
     id 'bio.terra.pfb.java-library-conventions'
     id 'com.github.davidmc24.gradle.plugin.avro' version '1.9.1'
     id 'me.champeau.jmh' version '0.7.3'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'bio.terra.pfb.java-library-conventions'
     id 'com.github.davidmc24.gradle.plugin.avro' version '1.9.1'
     id 'me.champeau.jmh' version '0.7.3'
-    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.5'
+    id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.1.5'
 }
 
 repositories {

--- a/library/publishing.gradle
+++ b/library/publishing.gradle
@@ -1,7 +1,3 @@
-//def artifactory_repo_key = System.getenv('ARTIFACTORY_REPO_KEY') != null ? System.getenv('ARTIFACTORY_REPO_KEY') : 'libs-release-local'
-//def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
-//def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')
-
 def garProjectId = System.getenv("GOOGLE_CLOUD_PROJECT")
 def garLocation = System.getenv("GAR_LOCATION")
 def garRepoId = System.getenv("GAR_REPOSITORY_ID")
@@ -11,13 +7,6 @@ java {
     // Builds sources into the published package as part of the 'assemble' task.
     withSourcesJar()
 }
-
-//gradle.taskGraph.whenReady { taskGraph ->
-//    if (taskGraph.hasTask(artifactoryPublish) &&
-//            (artifactory_username == null || artifactory_password == null)) {
-//        throw new GradleException('Set env vars ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to publish')
-//    }
-//}
 
 // Publish jar file to a Maven module/artifact using the maven-publish plugin.
 publishing {
@@ -35,20 +24,3 @@ publishing {
         }
     }
 }
-
-// Upload Maven artifacts to Artifactory using the Artifactory plugin.
-//artifactory {
-//    publish {
-//        contextUrl = 'https://broadinstitute.jfrog.io/broadinstitute/'
-//        repository {
-//            repoKey = "${artifactory_repo_key}"
-//            username = "${artifactory_username}"
-//            password = "${artifactory_password}"
-//        }
-//        defaults {
-//            publications('javaPfbLibrary')
-//            publishArtifacts = true
-//            publishPom = true
-//        }
-//    }
-//}

--- a/library/publishing.gradle
+++ b/library/publishing.gradle
@@ -1,18 +1,23 @@
-def artifactory_repo_key = System.getenv('ARTIFACTORY_REPO_KEY') != null ? System.getenv('ARTIFACTORY_REPO_KEY') : 'libs-release-local'
-def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
-def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')
+//def artifactory_repo_key = System.getenv('ARTIFACTORY_REPO_KEY') != null ? System.getenv('ARTIFACTORY_REPO_KEY') : 'libs-release-local'
+//def artifactory_username = System.getenv('ARTIFACTORY_USERNAME')
+//def artifactory_password = System.getenv('ARTIFACTORY_PASSWORD')
+
+def garProjectId = System.getenv("GOOGLE_CLOUD_PROJECT")
+def garLocation = System.getenv("GAR_LOCATION")
+def garRepoId = System.getenv("GAR_REPOSITORY_ID")
+
 
 java {
     // Builds sources into the published package as part of the 'assemble' task.
     withSourcesJar()
 }
 
-gradle.taskGraph.whenReady { taskGraph ->
-    if (taskGraph.hasTask(artifactoryPublish) &&
-            (artifactory_username == null || artifactory_password == null)) {
-        throw new GradleException('Set env vars ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to publish')
-    }
-}
+//gradle.taskGraph.whenReady { taskGraph ->
+//    if (taskGraph.hasTask(artifactoryPublish) &&
+//            (artifactory_username == null || artifactory_password == null)) {
+//        throw new GradleException('Set env vars ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD to publish')
+//    }
+//}
 
 // Publish jar file to a Maven module/artifact using the maven-publish plugin.
 publishing {
@@ -24,21 +29,26 @@ publishing {
             from components.java
         }
     }
-}
-
-// Upload Maven artifacts to Artifactory using the Artifactory plugin.
-artifactory {
-    publish {
-        contextUrl = 'https://broadinstitute.jfrog.io/broadinstitute/'
-        repository {
-            repoKey = "${artifactory_repo_key}"
-            username = "${artifactory_username}"
-            password = "${artifactory_password}"
-        }
-        defaults {
-            publications('javaPfbLibrary')
-            publishArtifacts = true
-            publishPom = true
+    repositories {
+        maven {
+            url = uri("artifactregistry://${garLocation}-maven.pkg.dev/${garProjectId}/${garRepoId}")
         }
     }
 }
+
+// Upload Maven artifacts to Artifactory using the Artifactory plugin.
+//artifactory {
+//    publish {
+//        contextUrl = 'https://broadinstitute.jfrog.io/broadinstitute/'
+//        repository {
+//            repoKey = "${artifactory_repo_key}"
+//            username = "${artifactory_username}"
+//            password = "${artifactory_password}"
+//        }
+//        defaults {
+//            publications('javaPfbLibrary')
+//            publishArtifacts = true
+//            publishPom = true
+//        }
+//    }
+//}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-593

Updates publishing artifacts from jfrog to GAR.  See https://github.com/DataBiosphere/java-pfb/actions/runs/16148436563 for a successful run and https://console.cloud.google.com/artifacts/maven/dsp-artifact-registry/us-central1/libs-release-standard/bio.terra:java-pfb-library?inv=1&invt=Ab2NzQ&project=dsp-artifact-registry to verify that it was, in fact, published; subsequent runs will either fail or just not try to publish since it should only do so on merge to main.